### PR TITLE
クイズ画面で使うプログレスバーを追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: HomeScreen(),
+      home: QuizScreen(),
     );
   }
 }

--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -1,12 +1,41 @@
 import 'package:flutter/material.dart';
 
-class QuizScreen extends StatelessWidget {
+import 'package:yrzy_hackathon/widgets/widgets.dart';
+
+class QuizScreen extends StatefulWidget {
+  @override
+  _QuizScreenState createState() => _QuizScreenState();
+}
+
+class _QuizScreenState extends State<QuizScreen> {
+  int _current = 0;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text('quiz_screen'),
-      )
+        bottom: PreferredSize(
+          child: ProgressBar(
+            max: 10, 
+            current: _current,
+            barColor: Colors.orange,
+          ), 
+          preferredSize: ProgressBar.preferredSize
+        ),
+      ),
+      body: Center(
+        child: TextButton(
+          onPressed: () {
+            setState(() {
+              _current = _current <= 9 
+                ? _current + 1 
+                : 0;
+            });
+          }, 
+          child: Text('次へ'),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -76,14 +76,14 @@ class _ProgressBarState extends State<ProgressBar> with TickerProviderStateMixin
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text(
-            '${this.widget.current} / ${this.widget.max}',
+            '${widget.current} / ${widget.max}',
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 4),
           CustomPaint(
             size: Size.fromHeight(8),
             foregroundPainter: _ProgressPainter(
-              barColor: this.widget.barColor, 
+              barColor: widget.barColor, 
               currentProgress: _animation.value,
             ),
           ),

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+class ProgressBar extends StatefulWidget {
+  /// `AppBar` の `bottom` に指定するために必要なサイズ.
+  static Size preferredSize = Size.fromHeight(40);
+
+  /// 分母となる最大値.
+  final int max;
+  /// 現在の値、この値は `max` 以下にならないとエラーになる.
+  final int current;
+  /// バーの色.
+  final Color barColor;
+
+  ProgressBar({
+    Key? key,
+    required this.max,
+    required this.current,
+    this.barColor = Colors.blue,
+  }): assert(current <= max), 
+      super(key: key);
+
+  @override
+  _ProgressBarState createState() => _ProgressBarState();
+}
+
+class _ProgressBarState extends State<ProgressBar> with TickerProviderStateMixin {
+  late Animation<double> _animation;
+  late final AnimationController _animationController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final end = widget.current / widget.max;
+    _animationController = AnimationController(vsync: this, duration: Duration(milliseconds: 200));
+    _animation = Tween<double>(begin: 0, end: end)
+      .animate(CurvedAnimation(parent: _animationController, curve: Curves.easeInOut))
+      ..addListener(() { 
+        setState(() { });
+      });
+
+    _animationController.forward();
+  }
+
+  @override
+  void didUpdateWidget(covariant ProgressBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.current != widget.current) {
+      final begin = oldWidget.current / oldWidget.max;
+      final end = widget.current / widget.max;
+
+      _animationController.duration = Duration(milliseconds: 200);
+      _animation = Tween(begin: begin, end: end)
+        .animate(CurvedAnimation(parent: _animationController, curve: Curves.easeInOut))
+        ..addListener(() {
+          setState(() { });
+        });
+
+      _animationController.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '${this.widget.current} / ${this.widget.max}',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          CustomPaint(
+            size: Size.fromHeight(8),
+            foregroundPainter: _ProgressPainter(
+              barColor: this.widget.barColor, 
+              currentProgress: _animation.value,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressPainter extends CustomPainter {
+  Color barColor;
+  double currentProgress;
+
+  _ProgressPainter({
+    required this.barColor,
+    required this.currentProgress,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final outerRrect = RRect.fromLTRBR(0, 0, size.width, size.height, Radius.circular(size.height / 2));
+    final innerRrect = RRect.fromLTRBR(0, 0, size.width * currentProgress, size.height, Radius.circular(size.height / 2));
+
+    final outerPaint = Paint();
+    outerPaint.color = Colors.black12;
+    final innerPaint = Paint();
+    innerPaint.color = barColor;
+    
+    canvas.drawRRect(outerRrect, outerPaint);
+    canvas.drawRRect(innerRrect, innerPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return currentProgress <= 100;
+  }
+}

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -10,12 +10,18 @@ class ProgressBar extends StatefulWidget {
   final int current;
   /// バーの色.
   final Color barColor;
+  /// テキスト部分の色.
+  final Color textColor;
+  /// バーの後ろの色.
+  final Color backgroundColor;
 
   ProgressBar({
     Key? key,
     required this.max,
     required this.current,
     this.barColor = Colors.blue,
+    this.textColor = Colors.black,
+    this.backgroundColor = Colors.black12,
   }): assert(current <= max), 
       super(key: key);
 
@@ -78,12 +84,16 @@ class _ProgressBarState extends State<ProgressBar> with TickerProviderStateMixin
           Text(
             '${widget.current} / ${widget.max}',
             textAlign: TextAlign.center,
+            style: TextStyle(
+              color: widget.textColor,
+            ),
           ),
           const SizedBox(height: 4),
           CustomPaint(
             size: Size.fromHeight(8),
             foregroundPainter: _ProgressPainter(
               barColor: widget.barColor, 
+              backgroundColor: widget.backgroundColor,
               currentProgress: _animation.value,
             ),
           ),
@@ -95,10 +105,12 @@ class _ProgressBarState extends State<ProgressBar> with TickerProviderStateMixin
 
 class _ProgressPainter extends CustomPainter {
   Color barColor;
+  Color backgroundColor;
   double currentProgress;
 
   _ProgressPainter({
     required this.barColor,
+    required this.backgroundColor,
     required this.currentProgress,
   });
 
@@ -108,7 +120,7 @@ class _ProgressPainter extends CustomPainter {
     final innerRrect = RRect.fromLTRBR(0, 0, size.width * currentProgress, size.height, Radius.circular(size.height / 2));
 
     final outerPaint = Paint();
-    outerPaint.color = Colors.black12;
+    outerPaint.color = backgroundColor;
     final innerPaint = Paint();
     innerPaint.color = barColor;
     

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export './progress_bar.dart';


### PR DESCRIPTION
## 📝 実装したこと

- `ProgressBar` ウィジェットを追加。
- サンプル用にクイズ画面に設置。

## 🏞 画面プレビュー

| Preview |
| :-: |
| ![Apr-15-2021 19-03-22](https://user-images.githubusercontent.com/31949692/114851954-4bed1180-9e1d-11eb-886a-150ea966a8a2.gif) |
