### PR TITLE
🆕 難易度のところで使う星を並べた Widget を追加

### DIFF
--- a/lib/widgets/star_rate.dart
+++ b/lib/widgets/star_rate.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class StarRate extends StatelessWidget {
+  /// 割合の値、色付きの星を表示する数.
+  final int rate;
+  /// 割合の最大値、星の数.
+  final int maxRate;
+  /// 星のサイズ.
+  final double size;
+  /// 色付きで表す星の色.
+  final Color fillColor;
+  /// 空(から)の星の色.
+  final Color blankColor;
+
+  const StarRate({
+    Key? key,
+    required this.rate,
+    this.maxRate = 5,
+    this.size = 24,
+    this.fillColor = Colors.yellow,
+    this.blankColor = Colors.grey,
+  }): assert(
+        0 <= rate, // `rate` は負の数を許可しない.
+        rate <= maxRate // `rate` は `maxRate` を超えない. 
+      ),
+      super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List<bool>.generate(maxRate, (index) => index < rate)
+        .map((isFill) {
+          return isFill 
+            ? Icon(
+              Icons.star_rounded,
+              size: size,
+              color: fillColor,
+            ) 
+            : Icon(
+              Icons.star_border_rounded,
+              size: size,
+              color: blankColor,
+            );
+        })
+        .toList(),
+    );
+  }
+}

--- a/lib/widgets/star_rate.dart
+++ b/lib/widgets/star_rate.dart
@@ -20,7 +20,7 @@ class StarRate extends StatelessWidget {
     this.fillColor = Colors.yellow,
     this.blankColor = Colors.grey,
   }): assert(
-        0 <= rate, // `rate` は負の数を許可しない.
+        rate >= 0, // `rate` は負の数を許可しない.
         rate <= maxRate // `rate` は `maxRate` を超えない. 
       ),
       super(key: key);

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,1 +1,2 @@
 export './progress_bar.dart';
+export './star_rate.dart';


### PR DESCRIPTION
## 📝 実装したこと

- クイズ画面の難易度の表示で使う星が並んだ Widget を追加

## 🏞 画面プレビュー

| Preview |
| :-: |
| <img width="303" alt="スクリーンショット 2021-04-17 19 10 05" src="https://user-images.githubusercontent.com/31949692/115109440-b5e9f000-9fb0-11eb-9d09-03b6d07340fe.png"> |
