### PR TITLE
🆕 アプリのテーマを作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:yrzy_hackathon/theme.dart';
 import 'package:yrzy_hackathon/screens/screens.dart';
 
 void main() {
@@ -11,6 +12,9 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: HomeScreen(),
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      themeMode: ThemeMode.system,
     );
   }
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  /// アプリのライトモードのテーマ
+  static final light = ThemeData.light().copyWith(
+    appBarTheme: AppBarTheme(
+      // AppBar の背景色
+      color: Colors.white,
+      shadowColor: Colors.black38,
+      // AppBar のタイトルのフォント設定
+      textTheme: TextTheme(
+        headline6: TextStyle(
+          color: Colors.grey.shade800,
+          fontSize: 20,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      // AppBar のアイコンの色
+      iconTheme: IconThemeData(
+        color: Colors.grey.shade600,
+      ),
+      // AppBar のアクションに設定したアイコンの色
+      actionsIconTheme: IconThemeData(
+        color: Colors.grey.shade600,
+      ),
+    ),
+  );
+
+  /// アプリのダークモードのテーマ
+  static final dark = ThemeData.dark();
+}


### PR DESCRIPTION
## 📝 実装したこと

- `AppTheme` クラスを作成。
- `MaterialApp` に作成したテーマを反映。
- ダークテーマにも対応させたいけど、色の指定を見直す必要があるので**一旦テーマデータだけ作りました**。

## 🏞 画面プレビュー

画面を作成、修正した場合は画像を添付しましょう。  
なければこのセクションを消してください。

| Before | After |
| :-: | :-: |
| ![Screenshot_1618735866](https://user-images.githubusercontent.com/31949692/115139755-ac26c200-a06e-11eb-9407-e3645bbe6e84.png) | ![Screenshot_1618734399](https://user-images.githubusercontent.com/31949692/115139719-68cc5380-a06e-11eb-8b84-135a157e7826.png) |
