### PR TITLE
🆕 一応ダークテーマをサポート

### DIFF
--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -100,6 +100,8 @@ class _QuizScreenState extends State<QuizScreen> {
           child: ProgressBar(
             max: _quizzes.isEmpty ? 1 : _quizzes.length,
             current: _quizzes.isEmpty ? 0 : _currentIndex + 1,
+            textColor: Theme.of(context).textTheme.caption?.color ?? Colors.black,
+            backgroundColor: Theme.of(context).dividerColor,
           ),
           preferredSize: ProgressBar.preferredSize,
         ),
@@ -123,7 +125,6 @@ class _QuizScreenState extends State<QuizScreen> {
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
-                color: Colors.black87,
               ),
             ),
             const SizedBox(height: 12,),

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -32,7 +32,7 @@ class ResultScreen extends StatelessWidget {
             padding: const EdgeInsets.all(40.0),
             child: Container(
               padding: const EdgeInsets.all(24.0),
-              color: Colors.white,
+              color: Theme.of(context).scaffoldBackgroundColor,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -21,7 +21,7 @@ class ProgressBar extends StatefulWidget {
     required this.current,
     this.barColor = Colors.blue,
     this.textColor = Colors.black,
-    this.backgroundColor = Colors.black12,
+    this.backgroundColor = Colors.grey,
   }): assert(current <= max), 
       super(key: key);
 
@@ -85,6 +85,7 @@ class _ProgressBarState extends State<ProgressBar> with TickerProviderStateMixin
             '${widget.current} / ${widget.max}',
             textAlign: TextAlign.center,
             style: TextStyle(
+              fontWeight: FontWeight.bold,
               color: widget.textColor,
             ),
           ),


### PR DESCRIPTION
## 📝 実装したこと

- テキストは基本的に色指定なしで、デフォルトの Theme から色を拾うように修正。
- 画像やアイコンは対応しようがないので、ライトでもダークでも同じ色で表示。
- 一部色指定を Theme から任意の色を拾うように修正。

## 🏞 画面プレビュー

### ホーム

| ホーム( Light ) | ホーム( Dark ) |
| :-: | :-: |
| ![Screenshot_1619850090](https://user-images.githubusercontent.com/31949692/116773665-b5ae2200-aa91-11eb-8275-afbfb580b854.png) | ![Screenshot_1619850116](https://user-images.githubusercontent.com/31949692/116773670-bfd02080-aa91-11eb-8590-f590aa4228d5.png) |

### 出題画面

| 出題画面( Light ) | 出題画面( Dark ) |
| :-: | :-: |
| ![Screenshot_1619850190](https://user-images.githubusercontent.com/31949692/116773685-e2623980-aa91-11eb-8441-4072779dc6f2.png) | ![Screenshot_1619850201](https://user-images.githubusercontent.com/31949692/116773690-ea21de00-aa91-11eb-930a-b8f8fb9ad70c.png) |

### 結果画面

| 結果画面( Light ) | 結果画面( Dark ) |
| :-: | :-: |
| ![Screenshot_1619850218](https://user-images.githubusercontent.com/31949692/116773707-fefe7180-aa91-11eb-8143-d6e0a5c50327.png) | ![Screenshot_1619850225](https://user-images.githubusercontent.com/31949692/116773713-07ef4300-aa92-11eb-93c7-fed16969af74.png) |
