### PR TITLE
🛠 クイズの問題数を設定するための下準備

### DIFF
--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -56,4 +56,11 @@ class Settings {
       ? value 
       : null;
   }
+
+  void remove({
+    required SettingsKey key
+  }) {
+    final keyString = _mapKeyToString(key);
+    _keyValue.remove(keyString);
+  }
 }

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -37,7 +37,7 @@ class Settings {
   }
 
   /// 指定したキーに対応する値をセットする.
-  void setValue<T>({
+  void setValue<T extends Comparable>({
     required SettingsKey key, 
     required T value
   }) {
@@ -51,7 +51,7 @@ class Settings {
 
     // NOTE: 念のため型のチェックをして、違うなら何もしない.
     final storedValue = _keyValue[keyString];
-    if (!storedValue is T) {
+    if (!(storedValue is T)) {
       return;
     }
 
@@ -59,7 +59,7 @@ class Settings {
   }
  
  /// 指定したキーに対応する値を取り出す.
-  T? getValue<T>({
+  T? getValue<T extends Comparable>({
     required SettingsKey key,
   }) {
     final keyString = _mapKeyToString(key);

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -1,15 +1,16 @@
-class SettingsManager {
+/// アプリに関する設定を管理するシングルトンクラス.
+class Settings {
 
   /// インスタンス保持用のプライベートな変数.
-  static SettingsManager? _instance;
+  static Settings? _instance;
 
-  static SettingsManager get instance {
+  static Settings get instance {
     final internal = _instance;
     if (internal != null) {
       return internal;
     }
 
-    final newInstance = SettingsManager._();
+    final newInstance = Settings._();
     _instance = newInstance;
 
     return newInstance;
@@ -17,5 +18,5 @@ class SettingsManager {
 
   // NOTE: 名前付きコンストラクタをプライベートにして、コンストラクタをプライベートでのみ利用できるようにしている.
   // こうすることで上記の `instance` からのみインスタンスを取得するように強制することができる.
-  SettingsManager._();
+  Settings._();
 }

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -1,3 +1,4 @@
+/// 設定として管理する項目を表すキーの一覧
 enum SettingsKey {
   /// クイズの問題数
   NumberOfQuiz
@@ -35,14 +36,29 @@ class Settings {
     }
   }
 
-  void setValue({
+  /// 指定したキーに対応する値をセットする.
+  void setValue<T>({
     required SettingsKey key, 
-    required dynamic value
+    required T value
   }) {
     final keyString = _mapKeyToString(key);
+
+    // NOTE: 初回の場合は Map に追加して終了.
+    if (!_keyValue.containsKey(keyString)) {
+      _keyValue.addEntries([MapEntry(keyString, value)]);
+      return;
+    }
+
+    // NOTE: 念のため型のチェックをして、違うなら何もしない.
+    final storedValue = _keyValue[keyString];
+    if (!storedValue is T) {
+      return;
+    }
+
     _keyValue.update(keyString, (_) => value);
   }
-
+ 
+ /// 指定したキーに対応する値を取り出す.
   T? getValue<T>({
     required SettingsKey key,
   }) {
@@ -57,6 +73,7 @@ class Settings {
       : null;
   }
 
+  /// 指定したキーと値を削除する.
   void remove({
     required SettingsKey key
   }) {

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -1,3 +1,8 @@
+enum SettingsKey {
+  /// クイズの問題数
+  NumberOfQuiz
+}
+
 /// アプリに関する設定を管理するシングルトンクラス.
 class Settings {
 
@@ -16,7 +21,39 @@ class Settings {
     return newInstance;
   }
 
+  Map<String, dynamic> _keyValue = {};
+
   // NOTE: 名前付きコンストラクタをプライベートにして、コンストラクタをプライベートでのみ利用できるようにしている.
   // こうすることで上記の `instance` からのみインスタンスを取得するように強制することができる.
   Settings._();
+
+  /// `Enum` から `String` に変換するメソッド.
+  String _mapKeyToString(SettingsKey key) {
+    switch (key) {
+      case SettingsKey.NumberOfQuiz:
+        return 'number_of_quiz';
+    }
+  }
+
+  void setValue({
+    required SettingsKey key, 
+    required dynamic value
+  }) {
+    final keyString = _mapKeyToString(key);
+    _keyValue.update(keyString, (_) => value);
+  }
+
+  T? getValue<T>({
+    required SettingsKey key,
+  }) {
+    final keyString = _mapKeyToString(key);
+    if (!_keyValue.containsKey(keyString)) {
+      return null;
+    }
+
+    final value = _keyValue[keyString];
+    return value is T 
+      ? value 
+      : null;
+  }
 }

--- a/lib/utils/settings_manager.dart
+++ b/lib/utils/settings_manager.dart
@@ -1,0 +1,21 @@
+class SettingsManager {
+
+  /// インスタンス保持用のプライベートな変数.
+  static SettingsManager? _instance;
+
+  static SettingsManager get instance {
+    final internal = _instance;
+    if (internal != null) {
+      return internal;
+    }
+
+    final newInstance = SettingsManager._();
+    _instance = newInstance;
+
+    return newInstance;
+  }
+
+  // NOTE: 名前付きコンストラクタをプライベートにして、コンストラクタをプライベートでのみ利用できるようにしている.
+  // こうすることで上記の `instance` からのみインスタンスを取得するように強制することができる.
+  SettingsManager._();
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,2 +1,3 @@
 export './fade_route.dart';
 export './json.dart';
+export './settings_manager.dart';

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,3 @@
 export './fade_route.dart';
 export './json.dart';
-export './settings_manager.dart';
+export 'settings.dart';

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('整数値の値が保存できること', () {
       final expectedValue = 1;
 
-      Settings.instance.setValue(key: SettingsKey.NumberOfQuiz, value: expectedValue);
+      Settings.instance.setValue<int>(key: SettingsKey.NumberOfQuiz, value: expectedValue);
 
       final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);
       expect(storedValue, equals(expectedValue));

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:yrzy_hackathon/utils/utils.dart';
+
+void main() {
+  group('Settings のテスト', () {    
+    test('整数値の値が保存できること', () {
+      final expectedValue = 1;
+
+      Settings.instance.setValue(key: SettingsKey.NumberOfQuiz, value: expectedValue);
+
+      final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);
+      expect(storedValue, equals(expectedValue));
+    });
+
+    test('整数値の値の更新ができること', () {
+      final expectedValue = 2;
+
+      Settings.instance.setValue<int>(key: SettingsKey.NumberOfQuiz, value: expectedValue);
+
+      final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);
+      expect(storedValue, equals(expectedValue));
+    });
+
+    test('すでに保持している値に対して、違う型の値で上書きはできないこと', () {
+      final expectedValue = 2;
+
+      Settings.instance.setValue<String>(key: SettingsKey.NumberOfQuiz, value: '1');
+
+      final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);
+      expect(storedValue, equals(expectedValue));
+    });
+
+    test('削除後は `null` が返されること', () {
+      Settings.instance.remove(key: SettingsKey.NumberOfQuiz);
+
+      final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);
+      expect(storedValue, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 📝 実装したこと

- 下準備としてアプリの設定を管理するシングルトンクラス `Settings` を実装
- ただしシングルトンで管理しているだけなので保存はされず、アプリを落とすとリセットされる

### 補足: Settings クラスの使い方

クイズの問題数を保存、取り出し、更新したい場合はこんな感じ。

```dart
// NOTE: 保存
final value = 5;
Settings.instance.setValue<int>(key: SettingsKey.NumberOfQuiz, value: value);

// NOTE: 取り出し
final storedValue = Settings.instance.getValue<int>(key: SettingsKey.NumberOfQuiz);

// NOTE: 更新
final newValue = 10;
Settings.instance.setValue<int>(key: SettingsKey.NumberOfQuiz, value: newValue);
```