### PR TITLE
🆕 数字選択用のピッカー付きモーダルを追加

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'package:yrzy_hackathon/screens/screens.dart';
 
 class HomeScreen extends StatelessWidget {

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,3 @@
 export './fade_route.dart';
 export './json.dart';
-export 'settings.dart';
+export './settings.dart';

--- a/lib/widgets/number_picker_sheet.dart
+++ b/lib/widgets/number_picker_sheet.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class NumberPickerSheet {
+
+  NumberPickerSheet._();
+
+  static Future<int?> show({
+    required BuildContext context,
+    required int itemNumber,
+    void Function(int)? onSelectedItemChanged,
+  }) async {
+    int? selectedItem;
+
+    await showModalBottomSheet<void>(
+      context: context, 
+      isDismissible: false,
+      builder: (_) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: CupertinoButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                }, 
+                child: Text(
+                  '完了',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              height: 220,
+              child: CupertinoPicker.builder(
+                itemExtent: 40,
+                childCount: itemNumber,
+                onSelectedItemChanged: (index) {
+                  final itemValue = index + 1;
+                  selectedItem = itemValue;
+
+                  if (onSelectedItemChanged != null) {
+                    onSelectedItemChanged(itemValue);
+                  }
+                }, 
+                itemBuilder: (_, index) {
+                  return Center(child: Text('${index + 1}'));
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
+        );
+      }
+    );
+
+    return selectedItem;
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,3 +1,4 @@
 export './correct_dialog.dart';
+export './number_picker_sheet.dart';
 export './progress_bar.dart';
 export './star_rate.dart';


### PR DESCRIPTION
## 📝 実装したこと

- 数字選択させる時に使えるピッカー付きのモーダルを追加

### 補足: 使い方

`Future<int?>` として選択した数値を返してくれるので、`await` して結果を受け取る。    
ユーザーが「完了」のボタンをタップしたタイミングで結果が返る。  

ただし、ユーザーが何も選択していない状態で「完了」ボタンをタップすることもできるので、`int?`となっていることに注意。

```dart
final selectedValue = await NumberPickerSheet.show(context: context, itemNumber: 10);
```

## 🏞 画面プレビュー

| iOS |
| :-: |
|  <img width="327" alt="スクリーンショット 2021-05-03 15 24 29" src="https://user-images.githubusercontent.com/31949692/116846683-d0b09b80-ac23-11eb-90f4-dcea2bdfce7f.png"> |
